### PR TITLE
Fix weird resize issue

### DIFF
--- a/static/js/chart-wheel.js
+++ b/static/js/chart-wheel.js
@@ -66,7 +66,7 @@ class ChartWheel {
         this.size = 600;
         this.canvas.width = this.size * this.dpr;
         this.canvas.height = this.size * this.dpr;
-        this.canvas.style.width = this.size + 'px';
+        
         this.ctx.scale(this.dpr, this.dpr);
         
         this.centerX = this.size / 2;


### PR DESCRIPTION

<img width="445" height="885" alt="NVIDIA_Overlay_w8UYG69NVS" src="https://github.com/user-attachments/assets/a956e60f-a94c-4e06-bd67-8d2b111a183d" />

Closes #59 

This pull request makes a minor adjustment to the rendering logic in `chart-wheel.js` by removing the explicit setting of the canvas element's CSS height property. This change likely allows the canvas to size itself more naturally or avoids conflicts with other style rules.

- Removed the line that set `this.canvas.style.height` in the `ChartWheel` class constructor, so the canvas height is no longer explicitly set via CSS.
