### PR TITLE
Oops I need to feed in the astrological data

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -207,21 +207,41 @@ def stream_calculate_full_chart(birth_date, birth_time, timezone_offset, latitud
         yield f"**Cosmic Note:** The AI astrologer is taking a cosmic tea break. ☕ You're as special and unique as the stars! 🔮"
 
 
-def stream_calculate_ask_anything(question):
+def stream_calculate_ask_anything(question, birth_date, birth_time, timezone_offset, latitude, longitude):
     """
-    Stream a general purpose answer for free-form questions.
+    Stream a general purpose answer for free-form questions with astrological context.
 
     Args:
         question (str): User's free-form question
+        birth_date (str): Birth date in YYYY/MM/DD format
+        birth_time (str): Birth time in HH:MM format
+        timezone_offset (str): Timezone offset
+        latitude (str): Latitude in flatlib format (e.g., 40n42)
+        longitude (str): Longitude in flatlib format (e.g., 74w00)
 
     Yields:
         str: Text chunks from AI streaming response
     """
+    chart, today_chart = create_charts(birth_date, birth_time, timezone_offset, latitude, longitude)
+    sun, moon, ascendant = get_main_positions(chart)
+    planets_in_houses = get_planets_in_houses(chart)
+    current_planets = get_current_planets(today_chart)
+
     user_prompt = (
         "Answer this question clearly and directly in a chill, friendly way. "
         "Be concise and practical, and use short bullets when useful. "
+        "Use the astrological context below to personalize your answer. "
         "If the question is ambiguous, make a reasonable assumption and state it briefly.\n\n"
-        f"Question: {question}"
+        f"Question: {question}\n\n"
+        f"Chart Data:\n"
+        f"Sun: {sun.sign}, Moon: {moon.sign}, Ascendant: {ascendant.sign}\n\n"
+        "Planets in Houses:\n" +
+        "\n".join([
+            f"{HOUSE_NAMES[house_number]}: " + ", ".join([f"{p['name']} in {p['sign']}" for p in house_data['planets']])
+            for house_number, house_data in planets_in_houses.items()
+        ]) +
+        "\n\nCurrent Planets status:\n" +
+        format_planets_for_api(current_planets)
     )
 
     system_content = (

--- a/routes.py
+++ b/routes.py
@@ -395,23 +395,35 @@ def stream_ask_anything():
     try:
         data = request.get_json() or {}
         question = (data.get('question') or '').strip()
-        birth_date = data.get('birth_date')
-        birth_time = data.get('birth_time')
-        timezone_offset = data.get('timezone_offset')
-        latitude = data.get('latitude')
-        longitude = data.get('longitude')
+
+        def _norm(v):
+            return v.strip() if isinstance(v, str) else v
+
+        birth_date = _norm(data.get('birth_date'))
+        birth_time = _norm(data.get('birth_time'))
+        timezone_offset = _norm(data.get('timezone_offset'))
+        latitude = _norm(data.get('latitude'))
+        longitude = _norm(data.get('longitude'))
 
         if not question:
             return jsonify({'error': 'Missing required field: question'}), 400
 
-        required_fields = ['birth_date', 'birth_time', 'timezone_offset', 'latitude', 'longitude']
-        missing_fields = [field for field in required_fields if field not in data or data.get(field) is None or data.get(field) == '']
+        required_fields = {
+            'birth_date': birth_date,
+            'birth_time': birth_time,
+            'timezone_offset': timezone_offset,
+            'latitude': latitude,
+            'longitude': longitude,
+        }
+        missing_fields = [
+            name for name, value in required_fields.items()
+            if value is None or (isinstance(value, str) and value == '')
+        ]
         if missing_fields:
             return jsonify({'error': f'Missing required fields: {", ".join(missing_fields)}'}), 400
 
         if birth_date and '-' in birth_date:
             birth_date = birth_date.replace('-', '/')
-
         from ai_service import get_client
         try:
             get_client()

--- a/routes.py
+++ b/routes.py
@@ -310,11 +310,35 @@ def live_mas():
 def ask_anything():
     """Render Ask Anything placeholder page immediately"""
     question = request.form.get('question_prompt', '').strip()
+    birth_date_html = request.form.get('birth_date', '').strip()
+    birth_time = request.form.get('birth_time', '').strip()
+    timezone_offset = request.form.get('timezone_offset', '').strip()
+    latitude = request.form.get('latitude', '').strip()
+    longitude = request.form.get('longitude', '').strip()
 
     if not question:
         return render_template('error.html', error="Please enter a question before using Ask Anything mode."), 400
 
-    return render_template('ask_anything.html', question=question, streaming=True)
+    required_fields = {
+        'birth_date': birth_date_html,
+        'birth_time': birth_time,
+        'timezone_offset': timezone_offset,
+        'latitude': latitude,
+        'longitude': longitude,
+    }
+    missing_fields = [name for name, value in required_fields.items() if not value]
+    if missing_fields:
+        return render_template('error.html', error="Please complete your birth details before using Ask Anything mode."), 400
+
+    form_data = {
+        'birth_date': birth_date_html,
+        'birth_time': birth_time,
+        'timezone_offset': timezone_offset,
+        'latitude': latitude,
+        'longitude': longitude,
+    }
+
+    return render_template('ask_anything.html', question=question, form_data=form_data, streaming=True)
 
 
 @app.route('/stream-live-mas-analysis', methods=['POST'])
@@ -371,9 +395,22 @@ def stream_ask_anything():
     try:
         data = request.get_json() or {}
         question = (data.get('question') or '').strip()
+        birth_date = data.get('birth_date')
+        birth_time = data.get('birth_time')
+        timezone_offset = data.get('timezone_offset')
+        latitude = data.get('latitude')
+        longitude = data.get('longitude')
 
         if not question:
             return jsonify({'error': 'Missing required field: question'}), 400
+
+        required_fields = ['birth_date', 'birth_time', 'timezone_offset', 'latitude', 'longitude']
+        missing_fields = [field for field in required_fields if field not in data or data.get(field) is None or data.get(field) == '']
+        if missing_fields:
+            return jsonify({'error': f'Missing required fields: {", ".join(missing_fields)}'}), 400
+
+        if birth_date and '-' in birth_date:
+            birth_date = birth_date.replace('-', '/')
 
         from ai_service import get_client
         try:
@@ -386,7 +423,7 @@ def stream_ask_anything():
 
         def generate():
             try:
-                for chunk in stream_calculate_ask_anything(question):
+                for chunk in stream_calculate_ask_anything(question, birth_date, birth_time, timezone_offset, latitude, longitude):
                     if chunk:
                         yield f"data: {json.dumps({'chunk': chunk})}\n\n"
                 yield f"data: {json.dumps({'done': True})}\n\n"

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -18,6 +18,34 @@ function closeModal(modalId) {
     }
 }
 
+function syncAskAnythingBirthFields() {
+    const fieldMap = [
+        ['birth_date', 'ask_birth_date'],
+        ['birth_time', 'ask_birth_time'],
+        ['timezone_offset', 'ask_timezone_offset'],
+        ['latitude', 'ask_latitude'],
+        ['longitude', 'ask_longitude']
+    ];
+
+    let missingSourceField = null;
+
+    fieldMap.forEach(([sourceId, targetId]) => {
+        const source = document.getElementById(sourceId);
+        const target = document.getElementById(targetId);
+        const value = source ? source.value : '';
+
+        if (target) {
+            target.value = value;
+        }
+
+        if (!missingSourceField && source && !value) {
+            missingSourceField = source;
+        }
+    });
+
+    return missingSourceField;
+}
+
 // Initialize modal listeners when DOM is ready
 function initializeModals() {
     // Open location help modal when button is clicked
@@ -32,10 +60,28 @@ function initializeModals() {
     const askAnythingBtn = document.getElementById('askAnythingBtn');
     if (askAnythingBtn) {
         askAnythingBtn.addEventListener('click', function() {
+            const missingField = syncAskAnythingBirthFields();
             openModal('askAnythingModal');
             const askInput = document.getElementById('question_prompt');
             if (askInput) {
                 askInput.focus();
+            }
+
+            if (missingField) {
+                missingField.reportValidity();
+            }
+        });
+    }
+
+    const askAnythingForm = document.querySelector('#askAnythingModal form');
+    if (askAnythingForm) {
+        askAnythingForm.addEventListener('submit', function(e) {
+            const missingField = syncAskAnythingBirthFields();
+            if (missingField) {
+                e.preventDefault();
+                closeModal('askAnythingModal');
+                missingField.focus();
+                missingField.reportValidity();
             }
         });
     }

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -68,7 +68,15 @@ function initializeModals() {
             }
 
             if (missingField) {
-                missingField.reportValidity();
+                if (missingField.id === 'latitude' || missingField.id === 'longitude') {
+                    openModal('locationHelpModal');
+                    const locationSearch = document.getElementById('locationSearch');
+                    if (locationSearch) {
+                        locationSearch.focus();
+                    }
+                } else {
+                    missingField.reportValidity();
+                }
             }
         });
     }
@@ -76,10 +84,19 @@ function initializeModals() {
     const askAnythingForm = document.querySelector('#askAnythingModal form');
     if (askAnythingForm) {
         askAnythingForm.addEventListener('submit', function(e) {
-            const missingField = syncAskAnythingBirthFields();
             if (missingField) {
                 e.preventDefault();
                 closeModal('askAnythingModal');
+
+                if (missingField.id === 'latitude' || missingField.id === 'longitude') {
+                    openModal('locationHelpModal');
+                    const locationSearch = document.getElementById('locationSearch');
+                    if (locationSearch) {
+                        locationSearch.focus();
+                    }
+                    return;
+                }
+
                 missingField.focus();
                 missingField.reportValidity();
             }

--- a/static/js/stream-analysis.js
+++ b/static/js/stream-analysis.js
@@ -81,7 +81,14 @@
     }
 
     const requestPayload = chartData.pageType === 'ask-anything'
-        ? { question: chartData.question }
+        ? {
+            question: chartData.question,
+            birth_date: chartData.birthDate,
+            birth_time: chartData.birthTime,
+            timezone_offset: chartData.timezoneOffset,
+            latitude: chartData.latitude,
+            longitude: chartData.longitude
+        }
         : {
             birth_date: chartData.birthDate,
             birth_time: chartData.birthTime,

--- a/templates/ask_anything.html
+++ b/templates/ask_anything.html
@@ -10,7 +10,12 @@
 <script>
     window.chartDataForStreaming = {
         pageType: 'ask-anything',
-        question: {{ question | tojson }}
+        question: {{ question | tojson }},
+        birthDate: {{ form_data.birth_date | tojson }},
+        birthTime: {{ form_data.birth_time | tojson }},
+        timezoneOffset: {{ form_data.timezone_offset | tojson }},
+        latitude: {{ form_data.latitude | tojson }},
+        longitude: {{ form_data.longitude | tojson }}
     };
 </script>
 {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -249,6 +249,11 @@
                     <label for="question_prompt">Your question:</label>
                     <textarea id="question_prompt" name="question_prompt" rows="4" placeholder="What do you want to know?" required></textarea>
                 </div>
+                <input type="hidden" id="ask_birth_date" name="birth_date">
+                <input type="hidden" id="ask_birth_time" name="birth_time">
+                <input type="hidden" id="ask_timezone_offset" name="timezone_offset">
+                <input type="hidden" id="ask_latitude" name="latitude">
+                <input type="hidden" id="ask_longitude" name="longitude">
                 <button type="submit">Get Answer 💬</button>
             </form>
         </div>

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -87,7 +87,14 @@ class TestTemplates(unittest.TestCase):
 
     def test_ask_anything_template_structure(self):
         """Test ask-anything template structure with streaming placeholder"""
-        response = self.app.post('/ask-anything', data={'question_prompt': 'How do I focus better?'})
+        response = self.app.post('/ask-anything', data={
+            'question_prompt': 'How do I focus better?',
+            'birth_date': '1988-08-08',
+            'birth_time': '10:30',
+            'timezone_offset': '0',
+            'latitude': '51n30',
+            'longitude': '00w07'
+        })
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'document.body.dataset.streaming', response.data)
         self.assertIn(b'stream-analysis.js', response.data)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,16 +33,43 @@ class TestAstroApp(unittest.TestCase):
 
     def test_ask_anything_route_valid_question(self):
         """Test ask-anything placeholder page renders for valid question"""
-        response = self.app.post('/ask-anything', data={'question_prompt': 'What should I cook tonight?'})
+        response = self.app.post('/ask-anything', data={
+            'question_prompt': 'What should I cook tonight?',
+            'birth_date': '1990-01-15',
+            'birth_time': '12:00',
+            'timezone_offset': '-05:00',
+            'latitude': '40n42',
+            'longitude': '74w00'
+        })
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Ask Anything', response.data)
         self.assertIn(b'document.body.dataset.streaming', response.data)
 
     def test_ask_anything_route_missing_question(self):
         """Test ask-anything route validates question input"""
-        response = self.app.post('/ask-anything', data={'question_prompt': '   '})
+        response = self.app.post('/ask-anything', data={
+            'question_prompt': '   ',
+            'birth_date': '1990-01-15',
+            'birth_time': '12:00',
+            'timezone_offset': '-05:00',
+            'latitude': '40n42',
+            'longitude': '74w00'
+        })
         self.assertEqual(response.status_code, 400)
         self.assertIn(b'Please enter a question', response.data)
+
+    def test_ask_anything_route_missing_birth_details(self):
+        """Test ask-anything route requires astrological birth details"""
+        response = self.app.post('/ask-anything', data={
+            'question_prompt': 'Should I switch jobs this year?',
+            'birth_date': '',
+            'birth_time': '12:00',
+            'timezone_offset': '-05:00',
+            'latitude': '40n42',
+            'longitude': '74w00'
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'birth details', response.data)
 
     def test_chart_route_missing_data(self):
         """Test chart route with missing form data"""

--- a/tests/test_streaming_endpoints.py
+++ b/tests/test_streaming_endpoints.py
@@ -398,7 +398,14 @@ class TestStreamingEndpointsSSE(unittest.TestCase):
         mock_stream_ask_anything.return_value = iter(['Answer part one. ', 'Answer part two.'])
 
         response = self.app.post('/stream-ask-anything',
-                                data=json.dumps({'question': 'What is a good morning routine?'}),
+                                data=json.dumps({
+                                    'question': 'What is a good morning routine?',
+                                    'birth_date': '1988-08-08',
+                                    'birth_time': '10:30',
+                                    'timezone_offset': '0',
+                                    'latitude': '51n30',
+                                    'longitude': '0w07'
+                                }),
                                 content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
@@ -417,7 +424,14 @@ class TestStreamingEndpointsSSE(unittest.TestCase):
     def test_stream_ask_anything_missing_question(self):
         """Test /stream-ask-anything validates required question field"""
         response = self.app.post('/stream-ask-anything',
-                                data=json.dumps({'question': '   '}),
+                                data=json.dumps({
+                                    'question': '   ',
+                                    'birth_date': '1988-08-08',
+                                    'birth_time': '10:30',
+                                    'timezone_offset': '0',
+                                    'latitude': '51n30',
+                                    'longitude': '0w07'
+                                }),
                                 content_type='application/json')
 
         self.assertEqual(response.status_code, 400)
@@ -431,12 +445,37 @@ class TestStreamingEndpointsSSE(unittest.TestCase):
         mock_get_client.side_effect = ValueError('ANTHROPIC_TOKEN not set')
 
         response = self.app.post('/stream-ask-anything',
-                                data=json.dumps({'question': 'What is the weather?' }),
+                                data=json.dumps({
+                                    'question': 'What is the weather?',
+                                    'birth_date': '1988-08-08',
+                                    'birth_time': '10:30',
+                                    'timezone_offset': '0',
+                                    'latitude': '51n30',
+                                    'longitude': '0w07'
+                                }),
                                 content_type='application/json')
 
         self.assertEqual(response.status_code, 503)
         response_data = json.loads(response.data)
         self.assertIn('error', response_data)
+
+    def test_stream_ask_anything_missing_birth_fields(self):
+        """Test /stream-ask-anything validates astrological birth fields"""
+        response = self.app.post('/stream-ask-anything',
+                                data=json.dumps({
+                                    'question': 'Should I move this year?',
+                                    'birth_date': '1988-08-08',
+                                    'birth_time': '',
+                                    'timezone_offset': '0',
+                                    'latitude': '51n30',
+                                    'longitude': '0w07'
+                                }),
+                                content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+        response_data = json.loads(response.data)
+        self.assertIn('error', response_data)
+        self.assertIn('birth_time', response_data['error'])
 
     @patch('calculations.stream_ai_api')
     @patch('calculations.get_current_planets')


### PR DESCRIPTION
This pull request enhances the "Ask Anything" feature by requiring and validating users' astrological birth details before generating personalized answers. It ensures that all relevant birth data is collected, passed through the backend and frontend, and included in the AI's context for more tailored responses. The changes also improve user experience by syncing and validating birth fields in the UI and updating tests to cover the new requirements.

**Backend validation and data flow improvements:**

* The `/ask-anything` and `/stream-ask-anything` endpoints now require all astrological birth details (`birth_date`, `birth_time`, `timezone_offset`, `latitude`, `longitude`) and return errors if any are missing. The backend passes these fields through to the AI service for personalized context. [[1]](diffhunk://#diff-4b0667727df51025d016d2e2ac846e0492f0a0a872227e1f1aebc14850edac30R313-R341) [[2]](diffhunk://#diff-4b0667727df51025d016d2e2ac846e0492f0a0a872227e1f1aebc14850edac30R398-R414) [[3]](diffhunk://#diff-4b0667727df51025d016d2e2ac846e0492f0a0a872227e1f1aebc14850edac30L389-R426) [[4]](diffhunk://#diff-68d099c56633a01cdfd76537637b77992954ff859d4828e04688a835e5d68c86L210-R244)

**Frontend synchronization and validation:**

* Hidden input fields for all birth details are added to the "Ask Anything" modal form, and JavaScript ensures these are synced from the main birth data fields. The UI now highlights missing fields before allowing submission. [[1]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R252-R256) [[2]](diffhunk://#diff-578a79ac358e275096182b104a70f72d980885a3e93f2b5d4fc0609171de9e2eR21-R48) [[3]](diffhunk://#diff-578a79ac358e275096182b104a70f72d980885a3e93f2b5d4fc0609171de9e2eR63-R85)

* The streaming JS and template are updated to include all birth details in the request payload for "Ask Anything" mode. [[1]](diffhunk://#diff-a2c3326c3e0b85d1f55ea472aed90090e1559ebf0804abd7186b64a4551ce084L84-R91) [[2]](diffhunk://#diff-339166747c2443170d5a73f7f1bbf30053cf26e95566a036d77af97eaf76c936L13-R18)

**Test coverage updates:**

* All relevant tests for the "Ask Anything" endpoints and UI are updated to supply the required birth details, and new tests are added to verify validation for missing birth fields. [[1]](diffhunk://#diff-c9bfdde749a4a61e65f7397be900e272dafb23c05fccdde91d2cc6168d5ab49eL90-R97) [[2]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7L36-R73) [[3]](diffhunk://#diff-b5bb0afda26a47ead2bf93e7260fbca3c486471d5e895a4cf959dda04301aaa0L401-R408) [[4]](diffhunk://#diff-b5bb0afda26a47ead2bf93e7260fbca3c486471d5e895a4cf959dda04301aaa0L420-R434) [[5]](diffhunk://#diff-b5bb0afda26a47ead2bf93e7260fbca3c486471d5e895a4cf959dda04301aaa0L434-R479)