### PR TITLE
Default to dark mode and always show chart wheel

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -6,7 +6,6 @@ from flask import Flask, render_template, request, Response, stream_with_context
 from config import logger, HOUSE_NAMES
 from formatters import markdown_filter, prepare_music_genre_text, format_planets_for_api
 from calculations import stream_calculate_chart, stream_calculate_full_chart, stream_calculate_live_mas, stream_calculate_ask_anything
-from launchdarkly_service import should_show_chart_wheel
 from chart_data import create_charts, get_main_positions, get_planets_in_houses, get_current_planets, get_full_chart_structure
 from ai_service import stream_ai_api
 from lastfm_service import get_top_tracks_by_genre, format_tracks_for_prompt
@@ -230,19 +229,9 @@ def full_chart():
 
     # Convert date format from YYYY-MM-DD to YYYY/MM/DD
     birth_date = birth_date_html.replace('-', '/')
-    
-    # Get user IP and check feature flag
-    user_ip = get_user_ip()
-    show_chart_wheel = should_show_chart_wheel(user_ip)
-
-    # In local development without LaunchDarkly configured, show the chart wheel
-    # so the full natal chart visualization can be previewed.
-    if not show_chart_wheel and app.debug and not os.environ.get('LAUNCHDARKLY_SDK_KEY'):
-        show_chart_wheel = True
 
     try:
         logger.info(f"Rendering full chart placeholder for: {birth_date} {birth_time} {timezone_offset} {latitude} {longitude}")
-        logger.info(f"Chart wheel display flag for IP {user_ip}: {show_chart_wheel}")
         
         # Calculate chart structure (fast - no AI)
         full_chart_data = get_full_chart_structure(birth_date, birth_time, timezone_offset, latitude, longitude)
@@ -259,7 +248,7 @@ def full_chart():
             'other_genre': request.form.get('other_genre', '')
         }
         
-        return render_template('full_chart.html', chart_data=full_chart_data, show_chart_wheel=show_chart_wheel, form_data=form_data, streaming=True)
+        return render_template('full_chart.html', chart_data=full_chart_data, form_data=form_data, streaming=True)
     except Exception as e:
         logger.error(f"ERROR in /full-chart route: {type(e).__name__}: {str(e)}")
         if app.debug:

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,12 +40,11 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/cosmic.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/button-effect.css') }}">
-    <!-- Dark mode: apply class before paint to prevent flash -->
+    <!-- Dark mode: apply class before paint to prevent flash. Defaults to dark unless the user opted out. -->
     <script>
       (function() {
         var saved = localStorage.getItem('theme');
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (saved === 'dark' || (!saved && prefersDark)) {
+        if (saved !== 'light') {
           document.documentElement.classList.add('dark');
         }
       })();

--- a/templates/full_chart.html
+++ b/templates/full_chart.html
@@ -112,8 +112,8 @@
   <!-- Chart wheel + placements -->
   <section class="chart-grid">
     <div class="chrome-border glass panel panel--wheel">
-      <div class="wheel-wrap" aria-label="Zodiac wheel">
-        <canvas id="chartWheel"></canvas>
+      <div class="wheel-wrap">
+        <canvas id="chartWheel" aria-label="Zodiac wheel natal chart visualization" role="img">Natal chart zodiac wheel</canvas>
       </div>
     </div>
 

--- a/templates/full_chart.html
+++ b/templates/full_chart.html
@@ -10,7 +10,6 @@
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="{{ url_for('static', filename='js/stream-analysis.js') }}"></script>
 {% endif %}
-{% if show_chart_wheel %}
 <script src="{{ url_for('static', filename='js/chart-wheel.js') }}"></script>
 <script>
     // Pass chart data to JavaScript
@@ -22,7 +21,6 @@
         houses: {{ chart_data.houses | tojson | safe }}
     };
 </script>
-{% endif %}
 <script>
     // Pass chart data to JavaScript for music suggestion
     window.chartDataForMusic = {
@@ -115,38 +113,7 @@
   <section class="chart-grid">
     <div class="chrome-border glass panel panel--wheel">
       <div class="wheel-wrap" aria-label="Zodiac wheel">
-        {% if show_chart_wheel %}
         <canvas id="chartWheel"></canvas>
-        {% else %}
-        <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
-          <defs>
-            <linearGradient id="holo" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stop-color="#c4b5fd"/>
-              <stop offset="50%" stop-color="#67e8f9"/>
-              <stop offset="100%" stop-color="#818cf8"/>
-            </linearGradient>
-          </defs>
-          <circle cx="200" cy="200" r="190" fill="none" stroke="url(#holo)" stroke-width="1.5"/>
-          <circle cx="200" cy="200" r="150" fill="none" stroke="currentColor" stroke-opacity="0.25"/>
-          <circle cx="200" cy="200" r="80" fill="none" stroke="currentColor" stroke-opacity="0.25"/>
-          <g stroke="currentColor" stroke-opacity="0.2">
-            <line x1="200" y1="10" x2="200" y2="390"/>
-            <line x1="10" y1="200" x2="390" y2="200"/>
-            <line x1="60" y1="60" x2="340" y2="340"/>
-            <line x1="340" y1="60" x2="60" y2="340"/>
-            <line x1="105" y1="22" x2="295" y2="378"/>
-            <line x1="295" y1="22" x2="105" y2="378"/>
-            <line x1="22" y1="105" x2="378" y2="295"/>
-            <line x1="22" y1="295" x2="378" y2="105"/>
-          </g>
-          <g fill="currentColor" font-family="Space Grotesk, system-ui, sans-serif" font-size="16" text-anchor="middle">
-            <text x="200" y="30">♈</text><text x="290" y="55">♉</text><text x="350" y="120">♊</text>
-            <text x="375" y="205">♋</text><text x="350" y="290">♌</text><text x="290" y="355">♍</text>
-            <text x="200" y="380">♎</text><text x="110" y="355">♏</text><text x="50" y="290">♐</text>
-            <text x="25" y="205">♑</text><text x="50" y="120">♒</text><text x="110" y="55">♓</text>
-          </g>
-        </svg>
-        {% endif %}
       </div>
     </div>
 

--- a/tests/test_chart_wheel.py
+++ b/tests/test_chart_wheel.py
@@ -27,7 +27,7 @@ class TestChartWheelVisualization(unittest.TestCase):
         for i in range(1, 13):
             houses[i] = {'sign': signs[i-1], 'degree': 10.0 + i}
 
-        with patch('routes.should_show_chart_wheel', return_value=True):
+        if True:
             form_data = {
                 'birth_date': '1995-07-10',
                 'birth_time': '14:30',
@@ -46,7 +46,7 @@ class TestChartWheelVisualization(unittest.TestCase):
         """Test that chart data is properly structured for JavaScript"""
         from unittest.mock import patch
 
-        with patch('routes.should_show_chart_wheel', return_value=True):
+        if True:
             form_data = {
                 'birth_date': '1990-04-15',
                 'birth_time': '12:00',
@@ -118,7 +118,7 @@ class TestChartWheelVisualization(unittest.TestCase):
         """Test that all 12 house cusps are properly handled"""
         from unittest.mock import patch
 
-        with patch('routes.should_show_chart_wheel', return_value=True):
+        if True:
             form_data = {
                 'birth_date': '1990-01-01',
                 'birth_time': '12:00',
@@ -243,7 +243,7 @@ class TestFullChartRoute(unittest.TestCase):
         """Test POST to full-chart with valid data"""
         from unittest.mock import patch
 
-        with patch('routes.should_show_chart_wheel', return_value=True):
+        if True:
             form_data = {
                 'birth_date': '1990-08-01',
                 'birth_time': '12:00',

--- a/tests/test_chart_wheel.py
+++ b/tests/test_chart_wheel.py
@@ -18,8 +18,6 @@ class TestChartWheelVisualization(unittest.TestCase):
 
     def test_full_chart_includes_canvas(self):
         """Test that full chart page includes canvas element"""
-        from unittest.mock import patch
-
         # Create complete house data (all 12 houses required)
         houses = {}
         signs = ['Cancer', 'Leo', 'Virgo', 'Libra', 'Scorpio', 'Sagittarius',
@@ -27,51 +25,45 @@ class TestChartWheelVisualization(unittest.TestCase):
         for i in range(1, 13):
             houses[i] = {'sign': signs[i-1], 'degree': 10.0 + i}
 
-        if True:
-            form_data = {
-                'birth_date': '1995-07-10',
-                'birth_time': '14:30',
-                'timezone_offset': '-8',
-                'latitude': '34n03',
-                'longitude': '118w14'
-            }
+        form_data = {
+            'birth_date': '1995-07-10',
+            'birth_time': '14:30',
+            'timezone_offset': '-8',
+            'latitude': '34n03',
+            'longitude': '118w14'
+        }
 
-            response = self.app.post('/full-chart', data=form_data)
-            self.assertEqual(response.status_code, 200)
+        response = self.app.post('/full-chart', data=form_data)
+        self.assertEqual(response.status_code, 200)
 
-            # Check for canvas element
-            self.assertIn(b'<canvas id="chartWheel"', response.data)
+        # Check for canvas element
+        self.assertIn(b'<canvas id="chartWheel"', response.data)
 
     def test_chart_data_structure(self):
         """Test that chart data is properly structured for JavaScript"""
-        from unittest.mock import patch
+        form_data = {
+            'birth_date': '1990-04-15',
+            'birth_time': '12:00',
+            'timezone_offset': '0',
+            'latitude': '40n42',
+            'longitude': '74w00'
+        }
 
-        if True:
-            form_data = {
-                'birth_date': '1990-04-15',
-                'birth_time': '12:00',
-                'timezone_offset': '0',
-                'latitude': '40n42',
-                'longitude': '74w00'
-            }
+        response = self.app.post('/full-chart', data=form_data)
+        self.assertEqual(response.status_code, 200)
 
-            response = self.app.post('/full-chart', data=form_data)
-            self.assertEqual(response.status_code, 200)
-
-            # Check that chart data is embedded in the page
-            self.assertIn(b'window.chartData', response.data)
-            
-            # Extract the chart data (check for presence of data structure)
-            response_text = response.data.decode('utf-8')
-            self.assertIn('planets:', response_text)
-            self.assertIn('houses:', response_text)
-            self.assertIn('Sun', response_text)
-            self.assertIn('Aries', response_text)
+        # Check that chart data is embedded in the page
+        self.assertIn(b'window.chartData', response.data)
+        
+        # Extract the chart data (check for presence of data structure)
+        response_text = response.data.decode('utf-8')
+        self.assertIn('planets:', response_text)
+        self.assertIn('houses:', response_text)
+        self.assertIn('Sun', response_text)
+        self.assertIn('Aries', response_text)
 
     def test_all_zodiac_signs_handled(self):
         """Test that all 12 zodiac signs are properly handled"""
-        from unittest.mock import patch
-
         zodiac_signs = [
             'Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo',
             'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'
@@ -91,8 +83,6 @@ class TestChartWheelVisualization(unittest.TestCase):
 
     def test_all_major_planets_handled(self):
         """Test that all major planets are properly handled"""
-        from unittest.mock import patch
-
         planets = ['Sun', 'Moon', 'Mercury', 'Venus', 'Mars', 
                    'Jupiter', 'Saturn', 'Uranus', 'Neptune', 'Pluto']
 
@@ -116,23 +106,20 @@ class TestChartWheelVisualization(unittest.TestCase):
 
     def test_house_cusps_all_present(self):
         """Test that all 12 house cusps are properly handled"""
-        from unittest.mock import patch
+        form_data = {
+            'birth_date': '1990-01-01',
+            'birth_time': '12:00',
+            'timezone_offset': '0',
+            'latitude': '0',
+            'longitude': '0'
+        }
 
-        if True:
-            form_data = {
-                'birth_date': '1990-01-01',
-                'birth_time': '12:00',
-                'timezone_offset': '0',
-                'latitude': '0',
-                'longitude': '0'
-            }
+        response = self.app.post('/full-chart', data=form_data)
+        self.assertEqual(response.status_code, 200)
 
-            response = self.app.post('/full-chart', data=form_data)
-            self.assertEqual(response.status_code, 200)
-
-            # Check that chart data includes basic structure
-            response_text = response.data.decode('utf-8')
-            self.assertIn('window.chartData', response_text)
+        # Check that chart data includes basic structure
+        response_text = response.data.decode('utf-8')
+        self.assertIn('window.chartData', response_text)
 
 
 class TestChartWheelJavaScript(unittest.TestCase):
@@ -241,20 +228,17 @@ class TestFullChartRoute(unittest.TestCase):
 
     def test_full_chart_post_with_valid_data(self):
         """Test POST to full-chart with valid data"""
-        from unittest.mock import patch
+        form_data = {
+            'birth_date': '1990-08-01',
+            'birth_time': '12:00',
+            'timezone_offset': '0',
+            'latitude': '0',
+            'longitude': '0'
+        }
 
-        if True:
-            form_data = {
-                'birth_date': '1990-08-01',
-                'birth_time': '12:00',
-                'timezone_offset': '0',
-                'latitude': '0',
-                'longitude': '0'
-            }
-
-            response = self.app.post('/full-chart', data=form_data)
-            self.assertEqual(response.status_code, 200)
-            self.assertIn(b'chartWheel', response.data)
+        response = self.app.post('/full-chart', data=form_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'chartWheel', response.data)
 
 
 if __name__ == '__main__':

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -71,7 +71,7 @@ class TestTemplates(unittest.TestCase):
         """Test full chart template structure with streaming placeholder"""
         from unittest.mock import patch
 
-        with patch('routes.should_show_chart_wheel', return_value=False):
+        if True:
             form_data = {
                 'birth_date': '1988-08-08',
                 'birth_time': '10:30',
@@ -294,58 +294,6 @@ class TestCSS(unittest.TestCase):
             self.assertIn('.sparkle', content)
             self.assertIn('.spinner', content)
             self.assertIn('@keyframes', content)
-
-
-class TestLaunchDarklyIntegration(unittest.TestCase):
-    """Test LaunchDarkly integration with routes"""
-
-    def setUp(self):
-        """Set up test client"""
-        self.app = app.test_client()
-        self.app.testing = True
-    
-    @patch('routes.should_show_chart_wheel')
-    @patch('routes.get_user_ip')
-    def test_full_chart_route_calls_feature_flag(self, mock_get_ip, mock_flag):
-        """Test that full chart route calls the LaunchDarkly feature flag with IP"""
-        mock_flag.return_value = True
-        mock_get_ip.return_value = "192.168.1.100"
-        
-        form_data = {
-            'birth_date': '1990-01-01',
-            'birth_time': '12:00',
-            'timezone_offset': '0',
-            'latitude': '40n42',
-            'longitude': '74w00',
-            'music_genre': 'rock'
-        }
-        
-        response = self.app.post('/full-chart', data=form_data)
-        
-        # The main thing we want to test is that the flag is being called with IP
-        mock_get_ip.assert_called_once()
-        mock_flag.assert_called_once_with("192.168.1.100")
-        
-        # Response should be successful
-        self.assertEqual(response.status_code, 200)
-        # Should contain streaming setup
-        self.assertIn(b'document.body.dataset.streaming', response.data)
-    
-    @patch('routes.should_show_chart_wheel')
-    @patch('routes.get_user_ip')
-    def test_ip_function_integration(self, mock_get_ip, mock_flag):
-        """Test that we can get user IP and call the flag function"""
-        mock_flag.return_value = False
-        mock_get_ip.return_value = "203.0.113.195"
-        
-        from routes import get_user_ip, app as routes_app
-        with routes_app.test_request_context('/', headers={'X-Forwarded-For': '203.0.113.195'}):
-            user_ip = get_user_ip()
-            self.assertEqual(user_ip, "203.0.113.195")
-                
-        # Test the flag function
-        result = mock_flag('203.0.113.195')
-        self.assertEqual(result, False)
 
 
 if __name__ == '__main__':

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,7 +1,6 @@
 import unittest
 import os
 import sys
-from unittest.mock import patch
 
 # Add the parent directory to the path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -69,23 +68,20 @@ class TestTemplates(unittest.TestCase):
 
     def test_full_chart_template_structure(self):
         """Test full chart template structure with streaming placeholder"""
-        from unittest.mock import patch
+        form_data = {
+            'birth_date': '1988-08-08',
+            'birth_time': '10:30',
+            'timezone_offset': '0',
+            'latitude': '51n30',
+            'longitude': '00w07'
+        }
 
-        if True:
-            form_data = {
-                'birth_date': '1988-08-08',
-                'birth_time': '10:30',
-                'timezone_offset': '0',
-                'latitude': '51n30',
-                'longitude': '00w07'
-            }
+        response = self.app.post('/full-chart', data=form_data)
+        self.assertEqual(response.status_code, 200)
 
-            response = self.app.post('/full-chart', data=form_data)
-            self.assertEqual(response.status_code, 200)
-
-            # Check for streaming setup
-            self.assertIn(b'document.body.dataset.streaming', response.data)
-            self.assertIn(b'stream-analysis.js', response.data)
+        # Check for streaming setup
+        self.assertIn(b'document.body.dataset.streaming', response.data)
+        self.assertIn(b'stream-analysis.js', response.data)
 
     def test_ask_anything_template_structure(self):
         """Test ask-anything template structure with streaming placeholder"""


### PR DESCRIPTION
## Summary

- **Dark mode by default**: the layout now defaults to dark mode while remaining toggleable. The pre-paint script in `base.html` applies the `dark` class unless the user has explicitly opted into light mode (persisted in `localStorage`).
- **Always show the chart wheel**: removed the LaunchDarkly `show-new-chart` feature flag that gated the full natal chart wheel. In production the flag defaulted to `false`, so the interactive wheel never loaded and the chart appeared broken/empty. The interactive `chart-wheel.js` canvas now always renders.

## Changes
- `routes.py` — removed the `should_show_chart_wheel` import and flag evaluation in the `/full-chart` route.
- `templates/base.html` — default theme is now dark unless opted out.
- `templates/full_chart.html` — always load the chart wheel; removed the static SVG placeholder fallback.
- `tests/` — removed the obsolete LaunchDarkly route-integration tests and updated chart-wheel tests for the flag removal.

## Testing
- All 183 tests pass.

Note: `launchdarkly_service.py` and its unit tests are left intact; the flag is simply no longer used to gate the chart.
