### PR TITLE
Add the copy button

### DIFF
--- a/static/js/music-suggestion.js
+++ b/static/js/music-suggestion.js
@@ -66,6 +66,11 @@ function loadMusicSuggestion(chartData, chartType) {
                                 container.appendChild(p);
                                 container.dataset.loaded = 'true';
                                 container.dataset.loading = 'false';
+
+                                const copyBtn = document.getElementById('copyAnalysisBtn');
+                                if (copyBtn && copyBtn.dataset.showAfterMusic === 'true') {
+                                    copyBtn.style.display = 'inline-flex';
+                                }
                             } else if (data.error) {
                                 console.error('Music suggestion error:', data.error);
                                 reader.cancel();

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -144,8 +144,8 @@
                 {% else %}
                 {{ chart_data.astrology_analysis | markdown | safe }}
                 {% endif %}
-                <div id="music-suggestion-placeholder" data-chart-type="daily"></div>
             </div>
+            <div id="music-suggestion-placeholder" data-chart-type="daily"></div>
         </section>
 
         <!-- The Sky is Listening Section -->

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -118,17 +118,35 @@
         {% endif %}
 
         <!-- Reading Content -->
-        <div class="reading-content" id="analysisContent" role="status" aria-live="polite" aria-busy="false" aria-atomic="false">
-            {% if streaming %}
-            <div class="streaming-analysis-text" id="analysisStreamContent"></div>
-            <div class="streaming-indicator" id="analysisStreamIndicator" aria-hidden="true">
-                <span class="streaming-indicator__icon" aria-hidden="true">✦</span>
-                <span class="sr-only">More content is still streaming in</span>
+        <section class="analysis-section"
+                 data-sun="{{ chart_data.sun }}"
+                 data-moon="{{ chart_data.moon }}"
+                 data-ascendant="{{ chart_data.ascendant }}">
+            <div class="section-cap">
+                <h3 class="section-title">Daily analysis</h3>
+                <button id="copyAnalysisBtn"
+                        class="copy-chip"
+                        onclick="copyAnalysis()"
+                        title="Copy your daily analysis"
+                        aria-label="Copy your daily analysis"
+                        data-show-after-music="true"
+                        style="display: none;">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                </button>
             </div>
-            {% else %}
-            {{ chart_data.astrology_analysis | markdown | safe }}
-            {% endif %}
-        </div>
+            <div class="reading-content" id="analysisContent" role="status" aria-live="polite" aria-busy="false" aria-atomic="false">
+                {% if streaming %}
+                <div class="streaming-analysis-text" id="analysisStreamContent"></div>
+                <div class="streaming-indicator" id="analysisStreamIndicator" aria-hidden="true">
+                    <span class="streaming-indicator__icon" aria-hidden="true">✦</span>
+                    <span class="sr-only">More content is still streaming in</span>
+                </div>
+                {% else %}
+                {{ chart_data.astrology_analysis | markdown | safe }}
+                {% endif %}
+                <div id="music-suggestion-placeholder" data-chart-type="daily"></div>
+            </div>
+        </section>
 
         <!-- The Sky is Listening Section -->
         <section class="listening-section">


### PR DESCRIPTION
This pull request adds a "Copy Daily Analysis" button to the daily analysis section and ensures it only appears after the music suggestion has loaded. It also improves the structure of the daily analysis section and prepares for music suggestions to be displayed.

**User interface improvements:**

* Added a "Copy Daily Analysis" button (`copyAnalysisBtn`) to the daily analysis section in `chart.html`, which is initially hidden and configured to appear only after the music suggestion loads.
* Updated the `loadMusicSuggestion` function in `music-suggestion.js` to display the copy button when the music suggestion has finished loading and the button is configured to show.

**Structural changes for analysis and music suggestion:**

* Wrapped the daily analysis content in a new `analysis-section` for better semantic structure and to hold relevant data attributes.
* Added a `music-suggestion-placeholder` div inside the analysis section to serve as the container for music suggestions.