### PR TITLE
Add the ability to download the chartwheel

### DIFF
--- a/static/css/cosmic.css
+++ b/static/css/cosmic.css
@@ -1573,7 +1573,27 @@ body.index-page .container > h1:first-of-type { display: none; }
   .chart-grid { grid-template-columns: 1fr 1fr; align-items: start; }
 }
 
-.panel--wheel { display: flex; align-items: center; justify-content: center; }
+.panel--wheel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+.wheel-cap {
+  width: 100%;
+  margin-bottom: 0.25rem;
+}
+.download-wheel-btn {
+  padding: 0.45rem 0.72rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.download-wheel-btn svg {
+  width: 13px;
+  height: 13px;
+}
 .wheel-wrap {
   width: 100%; max-width: 420px;
   aspect-ratio: 1 / 1;

--- a/static/js/chart-wheel.js
+++ b/static/js/chart-wheel.js
@@ -554,13 +554,67 @@ class ChartWheel {
 // Initialize chart when page loads
 document.addEventListener('DOMContentLoaded', function() {
     const chartCanvas = document.getElementById('chartWheel');
+    const downloadButton = document.getElementById('downloadChartWheelBtn');
+
     if (chartCanvas && window.chartData) {
         const wheel = new ChartWheel('chartWheel', window.chartData);
+
         // Redraw on dark/light theme changes so the wheel colors stay in sync
         const observer = new MutationObserver(function() {
             wheel.theme = wheel.resolveTheme();
             wheel.draw();
         });
         observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+        if (downloadButton) {
+            downloadButton.addEventListener('click', function() {
+                const getExportCanvas = function() {
+                    const exportCanvas = document.createElement('canvas');
+                    exportCanvas.width = chartCanvas.width;
+                    exportCanvas.height = chartCanvas.height;
+
+                    const exportCtx = exportCanvas.getContext('2d');
+                    if (!exportCtx) {
+                        return chartCanvas;
+                    }
+
+                    // Use the resolved page background so exported PNG has no transparency.
+                    const pageBackground = getComputedStyle(document.body).backgroundColor || '#ffffff';
+                    exportCtx.fillStyle = pageBackground;
+                    exportCtx.fillRect(0, 0, exportCanvas.width, exportCanvas.height);
+                    exportCtx.drawImage(chartCanvas, 0, 0);
+
+                    return exportCanvas;
+                };
+
+                const triggerDownload = function(url) {
+                    const link = document.createElement('a');
+                    link.href = url;
+                    link.download = 'chartWheel.png';
+                    document.body.appendChild(link);
+                    link.click();
+                    link.remove();
+                };
+
+                const exportCanvas = getExportCanvas();
+
+                if (exportCanvas.toBlob) {
+                    exportCanvas.toBlob(function(blob) {
+                        if (!blob) {
+                            return;
+                        }
+                        const objectUrl = URL.createObjectURL(blob);
+                        triggerDownload(objectUrl);
+                        window.setTimeout(function() {
+                            URL.revokeObjectURL(objectUrl);
+                        }, 1000);
+                    }, 'image/png');
+                    return;
+                }
+
+                const dataUrl = exportCanvas.toDataURL('image/png');
+                triggerDownload(dataUrl);
+            });
+        }
     }
 });

--- a/templates/full_chart.html
+++ b/templates/full_chart.html
@@ -116,6 +116,13 @@
   <!-- Chart wheel + placements -->
   <section class="chart-grid">
     <div class="chrome-border glass panel panel--wheel">
+      <div class="section-cap wheel-cap">
+        <h3 class="section-title">Chart wheel</h3>
+        <button id="downloadChartWheelBtn" class="pill-btn download-wheel-btn" type="button" aria-label="Download chart wheel image as PNG">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          <span>Download PNG</span>
+        </button>
+      </div>
       <div class="wheel-wrap">
         <canvas id="chartWheel" aria-label="Zodiac wheel natal chart visualization" role="img">Natal chart zodiac wheel</canvas>
       </div>


### PR DESCRIPTION
This pull request adds a feature that allows users to download the chart wheel as a PNG image, along with related UI and styling improvements. The main changes are grouped below:

**Feature: Download Chart Wheel as PNG**
* Added a "Download PNG" button to the chart wheel panel in `full_chart.html`, including an SVG icon and accessible labeling.
* Implemented the download functionality in `chart-wheel.js`: when the button is clicked, the current chart wheel is exported as a PNG image with the page background color (no transparency), and a download is triggered.

**UI and Styling Updates**
* Updated `.panel--wheel` in `cosmic.css` to use a column layout, added spacing, and styled the new download button and section cap for improved appearance and usability.