### PR TITLE
Fixes #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pip install -r requirements-dev.txt
 2. Set required environment variables. The easiest way for local development is a `.env` file (loaded automatically on startup):
 
 ```bash
-cp .env.example .env        # macOS/Linux
+cp .env.example .env           # macOS/Linux
 # Copy-Item .env.example .env  # Windows PowerShell
 ```
 

--- a/lastfm_service.py
+++ b/lastfm_service.py
@@ -10,6 +10,10 @@ from config import logger
 # Last.fm API configuration
 LASTFM_API_KEY = os.environ.get("LAST_FM_API_KEY")
 LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/"
+TOP_TIER_RATIO = 0.33
+MID_TIER_RATIO = 0.66
+TOP_TARGET_RATIO = 0.40
+MID_TARGET_RATIO = 0.35
 
 
 def select_varied_tracks(tracks, limit=30, seed_key=None):
@@ -31,15 +35,15 @@ def select_varied_tracks(tracks, limit=30, seed_key=None):
     if len(tracks) <= limit:
         return tracks[:]
 
-    top_end = max(1, int(len(tracks) * 0.33))
-    mid_end = max(top_end + 1, int(len(tracks) * 0.66))
+    top_end = max(1, int(len(tracks) * TOP_TIER_RATIO))
+    mid_end = max(top_end + 1, int(len(tracks) * MID_TIER_RATIO))
 
     top_tier = tracks[:top_end]
     mid_tier = tracks[top_end:mid_end]
     tail_tier = tracks[mid_end:]
 
-    top_target = max(1, int(round(limit * 0.40)))
-    mid_target = max(1, int(round(limit * 0.35)))
+    top_target = max(1, int(round(limit * TOP_TARGET_RATIO)))
+    mid_target = max(1, int(round(limit * MID_TARGET_RATIO)))
     tail_target = max(0, limit - top_target - mid_target)
 
     if seed_key is None:
@@ -71,13 +75,13 @@ def select_varied_tracks(tracks, limit=30, seed_key=None):
     return selected[:limit]
 
 
-def get_top_tracks_by_genre(genre, limit=20):
+def get_top_tracks_by_genre(genre, limit=30):
     """
     Fetch top tracks for a given genre from Last.fm API
     
     Args:
         genre (str): Music genre tag to search for
-        limit (int): Number of tracks to return (default 20, max 50)
+        limit (int): Number of tracks to return (default 30, max 50)
     
     Returns:
         list: List of track dictionaries with 'name' and 'artist' keys
@@ -141,13 +145,13 @@ def get_top_tracks_by_genre(genre, limit=20):
         return []
 
 
-def format_tracks_for_prompt(tracks, limit=20):
+def format_tracks_for_prompt(tracks, limit=30):
     """
     Format track list for inclusion in AI prompt
     
     Args:
         tracks (list): List of track dictionaries from get_top_tracks_by_genre
-        limit (int): Maximum number of tracks to include (default 20)
+        limit (int): Maximum number of tracks to include (default 30)
     
     Returns:
         str: Formatted string of tracks for prompt, or empty string if no tracks

--- a/tests/test_lastfm_service.py
+++ b/tests/test_lastfm_service.py
@@ -245,18 +245,18 @@ class TestFormatTracksForPrompt:
         valid_options = {f'- Song {i} by Artist {i}' for i in range(1, 11)}
         assert all(line in valid_options for line in lines)
     
-    def test_default_limit_is_20(self):
-        """Test that default limit is 20 tracks"""
+    def test_default_limit_is_30(self):
+        """Test that default limit is 30 tracks"""
         tracks = [
             {'name': f'Song {i}', 'artist': f'Artist {i}'}
-            for i in range(1, 25)
+            for i in range(1, 35)
         ]
         result = format_tracks_for_prompt(tracks)
 
         lines = [line for line in result.splitlines() if line.startswith('- ')]
-        assert len(lines) == 20
+        assert len(lines) == 30
 
-        valid_options = {f'- Song {i} by Artist {i}' for i in range(1, 25)}
+        valid_options = {f'- Song {i} by Artist {i}' for i in range(1, 35)}
         assert all(line in valid_options for line in lines)
     
     def test_handles_fewer_tracks_than_limit(self):


### PR DESCRIPTION
This pull request updates the way track tier ratios and limits are handled in the `lastfm_service.py` module. The main changes include centralizing tier ratio values as constants, increasing the default track limits for some functions, and updating the logic in `select_varied_tracks` to use the new constants.

Closes #110 

**Refactoring and configuration:**

* Defined tier ratio values (`TOP_TIER_RATIO`, `MID_TIER_RATIO`, `TOP_TARGET_RATIO`, `MID_TARGET_RATIO`) as constants at the top of `lastfm_service.py` to centralize configuration and improve maintainability.

**Logic and behavior changes:**

* Updated `select_varied_tracks` to use the new constants for tier boundaries and target counts instead of hardcoded values, making the logic easier to adjust and more consistent.

**Function signature and default parameter changes:**

* Increased the default `limit` parameter from 20 to 30 in both `get_top_tracks_by_genre` and `format_tracks_for_prompt` to allow for more tracks to be processed and formatted by default. [[1]](diffhunk://#diff-f69083c5af2d5a07df3162a6606d53940c8b244a3b28bb30a1a964dcb54f1a1dL74-R84) [[2]](diffhunk://#diff-f69083c5af2d5a07df3162a6606d53940c8b244a3b28bb30a1a964dcb54f1a1dL144-R154)