### PR TITLE
Centralize logic and fix local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ pip install -r requirements-dev.txt
 
 2. Set required environment variables. The easiest way for local development is a `.env` file (loaded automatically on startup):
 
+The app loads `.env` from the project root during startup for both `python run.py` and import-based servers like `gunicorn main:app`.
+
 ```bash
 cp .env.example .env           # macOS/Linux
 # Copy-Item .env.example .env  # Windows PowerShell

--- a/config.py
+++ b/config.py
@@ -14,15 +14,6 @@ def is_development_mode():
 
 IS_DEVELOPMENT = is_development_mode()
 
-# In development, load variables from a local .env file if present.
-if IS_DEVELOPMENT:
-    try:
-        from dotenv import load_dotenv
-        load_dotenv()
-    except ImportError:
-        # python-dotenv is optional; env vars can still be set in the shell.
-        pass
-
 from flatlib import const
 
 # Configure logging

--- a/config.py
+++ b/config.py
@@ -2,21 +2,40 @@
 Configuration and constants for the astrology application
 """
 import logging
+import os
 
-# Load environment variables from a .env file (if present) before anything
-# else reads them (e.g. ai_service.py reading ANTHROPIC_TOKEN at import time).
-try:
-    from dotenv import load_dotenv
-    load_dotenv()
-except ImportError:
-    # python-dotenv is optional; env vars can still be set in the shell.
-    pass
+
+def is_development_mode():
+    """Return True when Flask is running in development/debug mode."""
+    flask_env = os.environ.get('FLASK_ENV', '').strip().lower()
+    flask_debug = os.environ.get('FLASK_DEBUG', '').strip()
+    return flask_env == 'development' or flask_debug == '1'
+
+
+IS_DEVELOPMENT = is_development_mode()
+
+# In development, load variables from a local .env file if present.
+if IS_DEVELOPMENT:
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        # python-dotenv is optional; env vars can still be set in the shell.
+        pass
 
 from flatlib import const
 
 # Configure logging
 # Logging configuration is handled in main.py
 logger = logging.getLogger(__name__)
+
+
+def get_secret_key():
+    """Return configured Flask secret key or fail fast with a clear error."""
+    secret_key = os.environ.get('SECRET_KEY', '').strip()
+    if not secret_key:
+        raise RuntimeError('SECRET_KEY environment variable is required at startup.')
+    return secret_key
 
 # Filter for planets only (exclude house cusps, angles, etc.)
 PLANET_NAMES = ['Sun', 'Moon', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Uranus', 'Neptune', 'Pluto', 'Chiron']

--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ before any other astrological libraries are imported, then starts the Flask appl
 import os
 import logging
 
+# Ensure direct script execution defaults to local development behavior.
+if __name__ == '__main__':
+    os.environ.setdefault('FLASK_ENV', 'development')
+    os.environ.setdefault('FLASK_DEBUG', '1')
+
 # Configure logging
 log_level = os.environ.get('LOG_LEVEL', 'INFO')
 logging.basicConfig(level=getattr(logging, log_level), format='%(asctime)s - %(levelname)s - %(message)s')

--- a/main.py
+++ b/main.py
@@ -7,6 +7,14 @@ before any other astrological libraries are imported, then starts the Flask appl
 import os
 import logging
 
+try:
+    from dotenv import load_dotenv
+    PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+    load_dotenv(dotenv_path=os.path.join(PROJECT_ROOT, '.env'), override=False)
+except ImportError:
+    # python-dotenv is optional; env vars can still be set in the shell.
+    pass
+
 # Ensure direct script execution defaults to local development behavior.
 if __name__ == '__main__':
     os.environ.setdefault('FLASK_ENV', 'development')

--- a/main.py
+++ b/main.py
@@ -15,10 +15,18 @@ except ImportError:
     # python-dotenv is optional; env vars can still be set in the shell.
     pass
 
+
+def _is_debug_enabled():
+    """Return True when runtime should enable Flask debug behavior."""
+    return os.environ.get('FLASK_DEBUG', '').strip() == '1'
+
 # Ensure direct script execution defaults to local development behavior.
 if __name__ == '__main__':
-    os.environ.setdefault('FLASK_ENV', 'development')
-    os.environ.setdefault('FLASK_DEBUG', '1')
+    resolved_flask_env = os.environ.get('FLASK_ENV', '').strip().lower()
+    if not resolved_flask_env:
+        os.environ['FLASK_ENV'] = 'development'
+        resolved_flask_env = 'development'
+    os.environ.setdefault('FLASK_DEBUG', '1' if resolved_flask_env == 'development' else '0')
 
 # Configure logging
 log_level = os.environ.get('LOG_LEVEL', 'INFO')
@@ -56,4 +64,4 @@ logger.info(f"pyswisseph configured with absolute path: {abs_ephe_path}")
 from routes import app
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=_is_debug_enabled())

--- a/routes.py
+++ b/routes.py
@@ -1,23 +1,17 @@
 """Flask application bootstrap and blueprint registration."""
 
-import os
-
 from flask import Flask, request
-
-secret_key = os.environ.get('SECRET_KEY', '').strip()
-if not secret_key:
-    raise RuntimeError('SECRET_KEY environment variable is required at startup.')
 
 
 from ask_routes import ask_bp
 from chart_routes import chart_bp
-from config import logger
+from config import IS_DEVELOPMENT, get_secret_key, logger
 from formatters import markdown_filter
 from music_routes import music_bp
 
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = secret_key
+app.config['SECRET_KEY'] = get_secret_key()
 
 SITE_META = {
     'site_name': 'Astro Horoscope',
@@ -39,7 +33,7 @@ def inject_site_meta():
 
 
 # In development, disable static file caching so CSS/JS edits show on reload.
-if os.environ.get('FLASK_ENV') == 'development' or os.environ.get('FLASK_DEBUG') == '1':
+if IS_DEVELOPMENT:
     app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 
 app.template_filter('markdown')(markdown_filter)

--- a/run.py
+++ b/run.py
@@ -6,10 +6,26 @@ Run this script to start the web server
 
 import os
 
+
+def _is_debug_enabled():
+    """Return True when runtime should enable Flask debug behavior."""
+    return os.environ.get('FLASK_DEBUG', '').strip() == '1'
+
 if __name__ == '__main__':
+    try:
+        from dotenv import load_dotenv
+        project_root = os.path.dirname(os.path.abspath(__file__))
+        load_dotenv(dotenv_path=os.path.join(project_root, '.env'), override=False)
+    except ImportError:
+        # python-dotenv is optional; env vars can still be set in the shell.
+        pass
+
     # Running via this helper implies local development unless explicitly overridden.
-    os.environ.setdefault('FLASK_ENV', 'development')
-    os.environ.setdefault('FLASK_DEBUG', '1')
+    resolved_flask_env = os.environ.get('FLASK_ENV', '').strip().lower()
+    if not resolved_flask_env:
+        os.environ['FLASK_ENV'] = 'development'
+        resolved_flask_env = 'development'
+    os.environ.setdefault('FLASK_DEBUG', '1' if resolved_flask_env == 'development' else '0')
 
     from main import app
 
@@ -18,4 +34,4 @@ if __name__ == '__main__':
     print("🌟 Starting Astro Horoscope...")
     print(f"📍 Open your browser to: http://localhost:{port}")
     print("⏹️  Press Ctrl+C to stop the server")
-    app.run(host='0.0.0.0', port=port, debug=True)
+    app.run(host='0.0.0.0', port=port, debug=_is_debug_enabled())

--- a/run.py
+++ b/run.py
@@ -4,9 +4,14 @@ Astro Chart Calculator - Flask Web Application
 Run this script to start the web server
 """
 
+import os
+
 if __name__ == '__main__':
+    # Running via this helper implies local development unless explicitly overridden.
+    os.environ.setdefault('FLASK_ENV', 'development')
+    os.environ.setdefault('FLASK_DEBUG', '1')
+
     from main import app
-    import os
 
     port = int(os.environ.get("PORT", 8080))
 

--- a/tests/test_secret_key_config.py
+++ b/tests/test_secret_key_config.py
@@ -20,6 +20,8 @@ def _run_import_routes_with_env(env):
 def test_routes_import_fails_without_secret_key():
     env = os.environ.copy()
     env.pop('SECRET_KEY', None)
+    env['FLASK_ENV'] = 'production'
+    env.pop('FLASK_DEBUG', None)
 
     result = _run_import_routes_with_env(env)
 
@@ -30,6 +32,8 @@ def test_routes_import_fails_without_secret_key():
 def test_routes_import_succeeds_with_secret_key():
     env = os.environ.copy()
     env['SECRET_KEY'] = 'integration-test-secret-key'
+    env['FLASK_ENV'] = 'production'
+    env.pop('FLASK_DEBUG', None)
 
     result = _run_import_routes_with_env(env)
 


### PR DESCRIPTION
This pull request improves the configuration and startup process for the astrology application by making development and production environments more robust and explicit. The main changes ensure that environment variables are loaded appropriately, the Flask secret key is handled securely, and development mode behavior is consistent across entry points. Tests are also updated to reflect these changes.

**Environment configuration improvements:**
* Added an `is_development_mode()` helper and `IS_DEVELOPMENT` constant in `config.py` to centralize and clarify detection of development mode based on `FLASK_ENV` and `FLASK_DEBUG` environment variables. (`config.py`)
* Updated `main.py` and `run.py` to explicitly set `FLASK_ENV` and `FLASK_DEBUG` to development mode when running directly, ensuring predictable local development behavior. (`main.py`, `run.py`) [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R10-R14) [[2]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R7-L9)

**Secret key handling:**
* Moved the secret key retrieval and validation logic into a `get_secret_key()` function in `config.py`, raising a clear error if missing, and updated `routes.py` to use this function. (`config.py`, `routes.py`) [[1]](diffhunk://#diff-117426151e93a626f8b46bfdb3a95b3f4a62e5f4dd6e65975a7c50759bf04482R32-R39) [[2]](diffhunk://#diff-4b0667727df51025d016d2e2ac846e0492f0a0a872227e1f1aebc14850edac30L3-R14)

**Development mode behavior:**
* Updated static file caching logic in `routes.py` to use the new `IS_DEVELOPMENT` constant, ensuring that caching is disabled only in development mode. (`routes.py`)

**Testing updates:**
* Modified tests in `tests/test_secret_key_config.py` to explicitly set `FLASK_ENV` to `production` and clear `FLASK_DEBUG`, ensuring accurate simulation of production environment for secret key checks. (`tests/test_secret_key_config.py`) [[1]](diffhunk://#diff-c6e31146f9dabcdac677f7ad77686e901ed01f51a6040ac840f1bff368992266R23-R24) [[2]](diffhunk://#diff-c6e31146f9dabcdac677f7ad77686e901ed01f51a6040ac840f1bff368992266R35-R36)