### PR TITLE
Closes #128

### DIFF
--- a/static/js/datetime-input.js
+++ b/static/js/datetime-input.js
@@ -83,7 +83,8 @@
       ];
       if (navigation.indexOf(e.key) !== -1) return;
       if (e.ctrlKey || e.metaKey) return; // allow copy / paste / select-all
-      if (!/^\d$/.test(e.key)) {
+      // Only block printable characters; allow Enter/Escape/function keys, etc.
+      if (e.key.length === 1 && !/^\d$/.test(e.key)) {
         e.preventDefault();
       }
     });

--- a/static/js/datetime-input.js
+++ b/static/js/datetime-input.js
@@ -1,16 +1,41 @@
 /*
- * Free-typing date/time fields with a native picker fallback.
+ * Date/time fields with digit-only input, auto-delimiter insertion, clear on
+ * focus, and a native picker fallback.
  *
- * The visible Date/Time fields are plain text inputs so users can type a
- * far-away birth date directly (native <input type="date"> only lets you
- * edit fixed segments). A calendar/clock button opens the native picker,
- * and typed text is normalized to the canonical format on blur:
- *   date -> YYYY-MM-DD   time -> HH:MM (24h)
+ * UX behaviour:
+ *   - Focusing a field clears it so the user can type fresh.
+ *   - Only digit keys (0-9) are accepted; all other printable characters are
+ *     blocked.
+ *   - Delimiters are inserted automatically as the user types:
+ *       date: YYYY-MM-DD  (dashes added after position 4 and 6 of digits)
+ *       time: HH:MM       (colon added after position 2 of digits)
+ *   - On blur the value is validated; invalid entries are cleared.
+ *   - A calendar/clock button opens the native picker as a fallback.
  */
 (function () {
   'use strict';
 
   function pad(n) { return String(n).padStart(2, '0'); }
+
+  // Strip everything except digits.
+  function digitsOnly(s) {
+    return (s || '').replace(/\D/g, '');
+  }
+
+  // Format up-to-8 raw digits as YYYY-MM-DD (partial is fine while typing).
+  function formatDateDigits(digits) {
+    var d = digits.slice(0, 8);
+    if (d.length <= 4) return d;
+    if (d.length <= 6) return d.slice(0, 4) + '-' + d.slice(4);
+    return d.slice(0, 4) + '-' + d.slice(4, 6) + '-' + d.slice(6);
+  }
+
+  // Format up-to-4 raw digits as HH:MM (partial is fine while typing).
+  function formatTimeDigits(digits) {
+    var d = digits.slice(0, 4);
+    if (d.length <= 2) return d;
+    return d.slice(0, 2) + ':' + d.slice(2);
+  }
 
   function buildDate(y, mo, d) {
     var year = parseInt(y, 10);
@@ -22,51 +47,55 @@
     return String(year).padStart(4, '0') + '-' + pad(month) + '-' + pad(day);
   }
 
-  // Parse flexible date text into YYYY-MM-DD, or '' if unparseable.
+  // Validate a date string/digits into YYYY-MM-DD, or '' if invalid.
   function normalizeDate(text) {
-    var s = (text || '').trim();
-    if (!s) return '';
-    var m;
-    // YYYY-MM-DD / YYYY/MM/DD / YYYY.MM.DD
-    if ((m = s.match(/^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$/))) {
-      return buildDate(m[1], m[2], m[3]);
-    }
-    // MM/DD/YYYY / M/D/YYYY / MM-DD-YYYY (US order)
-    if ((m = s.match(/^(\d{1,2})[-/.](\d{1,2})[-/.](\d{4})$/))) {
-      return buildDate(m[3], m[1], m[2]);
-    }
-    // Plain 8 digits: YYYYMMDD
-    if ((m = s.match(/^(\d{4})(\d{2})(\d{2})$/))) {
-      return buildDate(m[1], m[2], m[3]);
-    }
-    // Month names: "July 15, 1990" / "15 Jul 1990"
-    var d = new Date(s);
-    if (!isNaN(d.getTime())) {
-      return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
-    }
-    return '';
+    var digits = digitsOnly(text);
+    if (digits.length !== 8) return '';
+    return buildDate(digits.slice(0, 4), digits.slice(4, 6), digits.slice(6, 8));
   }
 
-  // Parse flexible time text into HH:MM (24h), or '' if unparseable.
+  // Validate a time string/digits into HH:MM (24h), or '' if invalid.
   function normalizeTime(text) {
-    var s = (text || '').trim();
-    if (!s) return '';
-    var m = s.match(/^(\d{1,2})(?::?(\d{2}))?\s*([ap]\.?m\.?)?$/i);
-    if (!m) return '';
-    var h = parseInt(m[1], 10);
-    var min = m[2] ? parseInt(m[2], 10) : 0;
-    var ampm = m[3] ? m[3].toLowerCase().charAt(0) : '';
-    if (ampm === 'p' && h < 12) h += 12;
-    if (ampm === 'a' && h === 12) h = 0;
-    if (h > 23 || min > 59) return '';
-    return pad(h) + ':' + pad(min);
+    var digits = digitsOnly(text);
+    if (digits.length !== 4) return '';
+    var h = parseInt(digits.slice(0, 2), 10);
+    var m = parseInt(digits.slice(2, 4), 10);
+    if (h > 23 || m > 59) return '';
+    return pad(h) + ':' + pad(m);
   }
 
-  function wire(textId, nativeId, btnId, normalizer) {
+  function wire(textId, nativeId, btnId, formatter, normalizer) {
     var text = document.getElementById(textId);
     if (!text) return;
     var native = document.getElementById(nativeId);
     var btn = document.getElementById(btnId);
+
+    // Requirement 1: clear field on focus so the user can type fresh.
+    text.addEventListener('focus', function () {
+      text.value = '';
+    });
+
+    // Requirement 3: only accept digit keys (plus navigation/editing keys).
+    text.addEventListener('keydown', function (e) {
+      var navigation = [
+        'Backspace', 'Delete', 'ArrowLeft', 'ArrowRight',
+        'ArrowUp', 'ArrowDown', 'Tab', 'Home', 'End'
+      ];
+      if (navigation.indexOf(e.key) !== -1) return;
+      if (e.ctrlKey || e.metaKey) return; // allow copy / paste / select-all
+      if (!/^\d$/.test(e.key)) {
+        e.preventDefault();
+      }
+    });
+
+    // Requirement 2: auto-insert delimiters as digits accumulate.
+    text.addEventListener('input', function () {
+      var digits = digitsOnly(text.value);
+      var formatted = formatter(digits);
+      if (text.value !== formatted) {
+        text.value = formatted;
+      }
+    });
 
     if (btn && native) {
       btn.addEventListener('click', function () {
@@ -86,7 +115,7 @@
       });
     }
 
-    // Normalize free-typed text when the field loses focus.
+    // Validate and normalize when the field loses focus.
     text.addEventListener('blur', function () {
       var normalized = normalizer(text.value);
       var raw = (text.value || '').trim();
@@ -103,7 +132,7 @@
   }
 
   document.addEventListener('DOMContentLoaded', function () {
-    wire('birth_date', 'birth_date_native', 'birth_date_btn', normalizeDate);
-    wire('birth_time', 'birth_time_native', 'birth_time_btn', normalizeTime);
+    wire('birth_date', 'birth_date_native', 'birth_date_btn', formatDateDigits, normalizeDate);
+    wire('birth_time', 'birth_time_native', 'birth_time_btn', formatTimeDigits, normalizeTime);
   });
 })();

--- a/templates/index.html
+++ b/templates/index.html
@@ -128,7 +128,7 @@
           </button>
           <input type="date" id="birth_date_native" class="hidden-native-picker" tabindex="-1" aria-hidden="true">
         </div>
-        <span id="birth_date_hint" class="field-hint">Type or pick — e.g. 1990-07-15</span>
+        <span id="birth_date_hint" class="field-hint">Type digits — e.g. 19900715 → 1990-07-15</span>
       </div>
       <div class="field-group">
         <label for="birth_time">Time</label>
@@ -141,7 +141,7 @@
           </button>
           <input type="time" id="birth_time_native" class="hidden-native-picker" tabindex="-1" aria-hidden="true">
         </div>
-        <span id="birth_time_hint" class="field-hint">24-hour, e.g. 09:30 or 21:30</span>
+        <span id="birth_time_hint" class="field-hint">Type digits — e.g. 0930 → 09:30 (24-hour)</span>
       </div>
     </div>
 

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -55,21 +55,23 @@ class TestTemplates(unittest.TestCase):
         self.assertIn(b"addEventListener('input'", response.data)
 
     def test_datetime_input_date_hint_updated(self):
-        """Test that the date field placeholder reflects digits-only format"""
+        """Test that the date field hint reflects digits-only input and example formatting"""
         response = self.app.get('/')
         self.assertEqual(response.status_code, 200)
         response_text = response.data.decode('utf-8')
-        # birth_date field should be present
         self.assertIn('id="birth_date"', response_text)
-
+        self.assertIn('id="birth_date_hint"', response_text)
+        self.assertIn('19900715', response_text)
+        self.assertIn('1990-07-15', response_text)
     def test_datetime_input_time_hint_updated(self):
-        """Test that the time field placeholder reflects digits-only format"""
+        """Test that the time field hint reflects digits-only input and example formatting"""
         response = self.app.get('/')
         self.assertEqual(response.status_code, 200)
         response_text = response.data.decode('utf-8')
-        # birth_time field should be present
         self.assertIn('id="birth_time"', response_text)
-
+        self.assertIn('id="birth_time_hint"', response_text)
+        self.assertIn('0930', response_text)
+        self.assertIn('09:30', response_text)
     def test_index_template_renders(self):
         """Test that index template renders correctly"""
         response = self.app.get('/')

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -28,6 +28,48 @@ class TestTemplates(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'normalizeDate', response.data)
 
+    def test_datetime_input_clears_on_focus(self):
+        """Test that datetime input JS includes clear-on-focus behaviour"""
+        response = self.app.get('/static/js/datetime-input.js')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'focus', response.data)
+        self.assertIn(b"text.value = ''", response.data)
+
+    def test_datetime_input_digits_only(self):
+        """Test that datetime input JS restricts input to digits only"""
+        response = self.app.get('/static/js/datetime-input.js')
+        self.assertEqual(response.status_code, 200)
+        # Keydown handler that blocks non-digit keys
+        self.assertIn(b'keydown', response.data)
+        self.assertIn(b'preventDefault', response.data)
+        self.assertIn(b'/^\\d$/', response.data)
+
+    def test_datetime_input_auto_delimiter(self):
+        """Test that datetime input JS auto-inserts delimiters while typing"""
+        response = self.app.get('/static/js/datetime-input.js')
+        self.assertEqual(response.status_code, 200)
+        # Formatter functions for date and time
+        self.assertIn(b'formatDateDigits', response.data)
+        self.assertIn(b'formatTimeDigits', response.data)
+        # Input event handler drives auto-formatting
+        self.assertIn(b"addEventListener('input'", response.data)
+
+    def test_datetime_input_date_hint_updated(self):
+        """Test that the date field placeholder reflects digits-only format"""
+        response = self.app.get('/')
+        self.assertEqual(response.status_code, 200)
+        response_text = response.data.decode('utf-8')
+        # birth_date field should be present
+        self.assertIn('id="birth_date"', response_text)
+
+    def test_datetime_input_time_hint_updated(self):
+        """Test that the time field placeholder reflects digits-only format"""
+        response = self.app.get('/')
+        self.assertEqual(response.status_code, 200)
+        response_text = response.data.decode('utf-8')
+        # birth_time field should be present
+        self.assertIn('id="birth_time"', response_text)
+
     def test_index_template_renders(self):
         """Test that index template renders correctly"""
         response = self.app.get('/')


### PR DESCRIPTION
Closes #128 

This pull request updates the date and time input fields to provide a more user-friendly and error-resistant experience by enforcing digit-only entry, auto-formatting, and improved accessibility hints. It also adds corresponding frontend tests to ensure these behaviors. The most important changes are:

**Frontend JavaScript enhancements:**

* Refactored `static/js/datetime-input.js` to enforce digit-only input for date and time fields, automatically insert delimiters (e.g., dashes and colons) as the user types, clear the field on focus, and validate input strictly to canonical formats (`YYYY-MM-DD` for dates, `HH:MM` for times). [[1]](diffhunk://#diff-81ba51b1dde9e88d7b42ebfe66451da9e6930b7eb21a9619acb00f9d2d01196cL2-R39) [[2]](diffhunk://#diff-81ba51b1dde9e88d7b42ebfe66451da9e6930b7eb21a9619acb00f9d2d01196cL25-R99) [[3]](diffhunk://#diff-81ba51b1dde9e88d7b42ebfe66451da9e6930b7eb21a9619acb00f9d2d01196cL89-R118) [[4]](diffhunk://#diff-81ba51b1dde9e88d7b42ebfe66451da9e6930b7eb21a9619acb00f9d2d01196cL106-R136)

**UI/UX improvements:**

* Updated field hints in `templates/index.html` to reflect the new digits-only input method and provide clear examples for users. [[1]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L131-R131) [[2]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L144-R144)

**Automated testing:**

* Added new tests in `tests/test_frontend.py` to verify clear-on-focus behavior, digit-only restrictions, auto-delimiter insertion, and that the updated hints are present in the rendered HTML.